### PR TITLE
Use correct library name

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -20,7 +20,7 @@ unittest:
       - "LiquidCrystal"
       - "RTClib"
       - "Adafruit BusIO"
-      - "Adafruit_MAX31865"
+      - "Adafruit MAX31865"
 
 compile:
     platforms:
@@ -29,5 +29,5 @@ compile:
       - "LiquidCrystal"
       - "RTClib"
       - "Adafruit BusIO"
-      - "Adafruit_MAX31865"
+      - "Adafruit MAX31865"
 


### PR DESCRIPTION
Although the local library folder is `Adafruit_MAX31865 `, [trying to install a library by that name fails](https://github.com/Open-Acidification/TankControllerLib/pull/11/checks?check_run_id=1378029595#step:6:69).

I believe the correct name for the library is `Adafruit MAX31865`